### PR TITLE
Removal of debug output

### DIFF
--- a/jobs/dockerhub.rb
+++ b/jobs/dockerhub.rb
@@ -35,8 +35,6 @@ SCHEDULER.every '1m', :first_in => 0 do |job|
       repoArray.push({title: repoTitle, stars: repoStars.to_i, pulls: repoPulls.to_i})
     end
   end
-  puts "Full array:"
-  puts repoArray
   repos_stars = Array.new
   repos_pulls = Array.new
   repoArray.each do |repo|
@@ -52,9 +50,6 @@ SCHEDULER.every '1m', :first_in => 0 do |job|
   if ordered
     repos_stars = repos_stars.sort_by { |obj| -obj[:value] }
     repos_pulls = repos_pulls.sort_by { |obj| -obj[:value] }
-    puts "Ordered:"
-    puts repos_stars
-    puts repos_pulls
   end
   send_event('docker_hub_stars', { items: repos_stars.slice(0, max_length) })
   send_event('docker_hub_pulls', { items: repos_pulls.slice(0, max_length) })


### PR DESCRIPTION
No need to have the Docker widget to spit out a ton of debug logs